### PR TITLE
feat(network): 添加主机名到IPv4地址解析功能

### DIFF
--- a/ezorsia/dllmain.cpp
+++ b/ezorsia/dllmain.cpp
@@ -7,6 +7,49 @@
 #include <comutil.h>
 #include "BossHP.h"
 
+// config.ini can use IP or hostname (ServerIP_Address=...).
+// The patch expects an IPv4 dotted string; resolve hostnames to IPv4.
+// On failure, fall back to the original value.
+static std::string ResolveToIpv4String(const std::string& hostOrIp)
+{
+	if (hostOrIp.empty()) return hostOrIp;
+
+	IN_ADDR parsedAddr{};
+	if (InetPtonA(AF_INET, hostOrIp.c_str(), &parsedAddr) == 1) {
+		return hostOrIp;
+	}
+
+	WSADATA wsaData{};
+	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
+		return hostOrIp;
+	}
+
+	addrinfo hints{};
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+
+	addrinfo* result = nullptr;
+	const int gaiRc = getaddrinfo(hostOrIp.c_str(), nullptr, &hints, &result);
+	if (gaiRc != 0 || result == nullptr) {
+		WSACleanup();
+		return hostOrIp;
+	}
+
+	char ipBuf[INET_ADDRSTRLEN]{};
+	const auto* ipv4 = reinterpret_cast<const sockaddr_in*>(result->ai_addr);
+	const PCSTR ipStr = InetNtopA(AF_INET, const_cast<IN_ADDR*>(&ipv4->sin_addr), ipBuf, sizeof(ipBuf));
+
+	freeaddrinfo(result);
+	WSACleanup();
+
+	if (ipStr == nullptr) {
+		return hostOrIp;
+	}
+
+	return std::string(ipStr);
+}
+
 void CreateConsole() {
 	AllocConsole();
 	FILE* stream;
@@ -45,7 +88,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 			ownLoginFrame = reader.GetBoolean("optional", "ownLoginFrame", false);
 			ownCashShopFrame = reader.GetBoolean("optional", "ownCashShopFrame", false);
 			EzorsiaV2WzIncluded = reader.GetBoolean("general", "EzorsiaV2WzIncluded", true);
-			Client::ServerIP_AddressFromINI = reader.Get("general", "ServerIP_Address", "127.0.0.1");
+			Client::ServerIP_AddressFromINI = ResolveToIpv4String(reader.Get("general", "ServerIP_Address", "127.0.0.1"));
 			Client::serverIP_Port = reader.GetInteger("general", "serverIP_Port", 8484);
 			Client::climbSpeedAuto = reader.GetBoolean("optional", "climbSpeedAuto", false);
 			Client::climbSpeed = reader.GetFloat("optional", "climbSpeed", 1.0);
@@ -98,3 +141,4 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 	}
 	return TRUE;
 }
+

--- a/ezorsia/stdafx.h
+++ b/ezorsia/stdafx.h
@@ -2,7 +2,15 @@
 
 #include "targetver.h"
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#endif
+
+// Include before <windows.h> to avoid winsock.h conflicts.
+// Needed for hostname->IPv4 resolution (getaddrinfo/InetPton/InetNtop).
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
 // Windows Header Files
 #include <windows.h>
 
@@ -11,3 +19,4 @@
 #include <iostream>
 #include "Client.h"
 #include "Memory.h"
+


### PR DESCRIPTION
- 实现ResolveToIpv4String函数，支持将主机名解析为IPv4地址
- 在配置文件读取服务器IP时自动进行主机名解析
- 添加winsock2.h和ws2tcpip.h头文件支持网络解析功能
- 当解析失败时回退到原始IP地址值
- 修复了可能的空指针访问问题